### PR TITLE
Install script fix

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -28,6 +28,9 @@ tar xzf /tmp/rekon.tar.gz -C /tmp/extract-rekon
 # Move crazy gitub adamhunter-sha directory to standardized path
 mv -f /tmp/extract-rekon/*/* /tmp/rekon/
 
+# Enable execution bit for install script
+chmod u+x /tmp/rekon/install.sh
+
 # Run downloaded installer script
 /tmp/rekon/install.sh $node;
 


### PR DESCRIPTION
currently, the install script assumes extracted shell script will be executable. I found this not to be the case by default on my osx 10.6.6

Here is the fix.
