### PR TITLE
download.sh OSX check fix

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -40,7 +40,7 @@ rm -rf /tmp/extract-rekon /tmp/rekon
 echo
 echo "Install Completed!"
 
-if [ `uname | grep darwin` ]; then
+if [ `uname | grep Darwin` ]; then
   # if we are macking OSX, use open to take the user to rekon
   echo "Opening http://$node/buckets/rekon/keys/go#/buckets"
   open "http://$node/buckets/rekon/keys/go#/buckets"


### PR DESCRIPTION
Checking for OSX works in OSX but not in Linux defaulting to Bash, looked at a few shell tricks, nasty.. went for alternative.

root@vagrant-precise-pangolin:/vagrant# echo $SHELL
/bin/bash

root@vagrant-precise-pangolin:/vagrant# curl -s -L rekon.basho.com | sh

Begining Install into 127.0.0.1:8098...
Downloading Rekon from Github

Download Completed
Extracting Source
Installing rekon to 127.0.0.1:8098...
Installed, now visit: http://127.0.0.1:8098/buckets/rekon/keys/go

Install Completed!
sh: 43: [: ==: unexpected operator

---

Visit http://127.0.0.1:8098/buckets/rekon/keys/go in your browser

---

Amended download.sh:43

if [ $OSTYPE == 'darwin10.0' ]; then

to

if [ `uname | grep Darwin` ]; then
