### PR TITLE
Bucket name being encoded twice when retrieving keys.

### DIFF
--- a/app/rekon.js
+++ b/app/rekon.js
@@ -52,7 +52,7 @@ rekonApp = Sammy('#container', function(){
 
     bucket.keys(function(keys) {
       if (keys.length > 0) {
-        keyRows = keys.map(function(key) { return {bucket:encode(name), key:encode(key)}; });
+        keyRows = keys.map(function(key) { return {bucket:name, key:encode(key)}; });
         context.renderEach('key-row.html.template', keyRows).replace('#keys tbody').then(
           function(){ searchable('#bucket table tbody tr'); }
         );


### PR DESCRIPTION
Fixed a bug when loading keys for buckets that was causing the bucket name to be encoded twice. This caused buckets with spaces in the name to have an encoded %25 (the % symbol) in them. So a space would be changed to %2520.

Signed-off-by: Chris Pomerantz chris@fluiddataconcepts.com
